### PR TITLE
Update shards to crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.2
 authors:
   - Linas Juškevičius <linas@prodigito.lt>
 
-crystal: 0.35.1
+crystal: ">= 0.35.1, < 2.0.0"
 
 dependencies:
   db:


### PR DESCRIPTION
update to allow error less install on crystal 1.0.0. Currently errors out due to major version change on shards install.

there also should be a new version release as well.